### PR TITLE
Add OOB IP ping test page and fix CSRF handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,319 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NetBox DCIM - OOB IP Ping Test</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <meta name="csrf-token" content="test-csrf-token-12345" />
+  </head>
+  <body>
+    <div class="container-fluid mt-4">
+      <div class="row">
+        <div class="col-12">
+          <div class="alert alert-info">
+            <h5 class="alert-heading">
+              ✅ OOB IP Ping Functionality - Test Page
+            </h5>
+            <p>
+              This page demonstrates the fixed OOB IP ping functionality for
+              NetBox DCIM devices.
+            </p>
+            <hr />
+            <p class="mb-0"><strong>Recent Fixes Applied:</strong></p>
+            <ul class="mb-0">
+              <li>
+                Fixed CSRF token handling (removed @csrf_exempt, improved token
+                detection)
+              </li>
+              <li>Added comprehensive error handling and debugging logs</li>
+              <li>Fixed missing Column import in device tables</li>
+              <li>Improved button state management and user feedback</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header bg-primary text-white">
+              <h5 class="card-title mb-0">
+                🌐 Device Table with OOB IP Ping Status
+              </h5>
+              <small
+                >Test the ping functionality below - check browser console for
+                debugging info</small
+              >
+            </div>
+            <div class="card-body">
+              <div class="table-responsive">
+                <table class="table table-striped table-hover">
+                  <thead class="table-dark">
+                    <tr>
+                      <th>Device Name</th>
+                      <th>Site</th>
+                      <th>Role</th>
+                      <th>Primary IP</th>
+                      <th>OOB IP</th>
+                      <th>OOB IP Ping Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><strong>router-core-01</strong></td>
+                      <td>New York DC</td>
+                      <td><span class="badge bg-primary">Core Router</span></td>
+                      <td>192.168.1.1/24</td>
+                      <td>10.0.0.1/30</td>
+                      <td>
+                        <button
+                          class="btn btn-sm btn-outline-primary oob-ping-btn"
+                          data-ip="10.0.0.1"
+                          onclick="pingOobIP(this)"
+                        >
+                          Ping
+                        </button>
+                        <span
+                          class="oob-ping-result ms-2"
+                          style="display: none"
+                        ></span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><strong>switch-access-01</strong></td>
+                      <td>New York DC</td>
+                      <td>
+                        <span class="badge bg-success">Access Switch</span>
+                      </td>
+                      <td>192.168.1.10/24</td>
+                      <td>10.0.0.10/30</td>
+                      <td>
+                        <button
+                          class="btn btn-sm btn-outline-primary oob-ping-btn"
+                          data-ip="10.0.0.10"
+                          onclick="pingOobIP(this)"
+                        >
+                          Ping
+                        </button>
+                        <span
+                          class="oob-ping-result ms-2"
+                          style="display: none"
+                        ></span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><strong>firewall-edge-01</strong></td>
+                      <td>Los Angeles DC</td>
+                      <td>
+                        <span class="badge bg-danger">Edge Firewall</span>
+                      </td>
+                      <td>192.168.2.1/24</td>
+                      <td>10.0.1.1/30</td>
+                      <td>
+                        <button
+                          class="btn btn-sm btn-outline-primary oob-ping-btn"
+                          data-ip="10.0.1.1"
+                          onclick="pingOobIP(this)"
+                        >
+                          Ping
+                        </button>
+                        <span
+                          class="oob-ping-result ms-2"
+                          style="display: none"
+                        ></span>
+                      </td>
+                    </tr>
+                    <tr class="table-success">
+                      <td><strong>test-google-dns</strong></td>
+                      <td>External Test</td>
+                      <td><span class="badge bg-info">Test Device</span></td>
+                      <td>N/A</td>
+                      <td>8.8.8.8</td>
+                      <td>
+                        <button
+                          class="btn btn-sm btn-outline-success oob-ping-btn"
+                          data-ip="8.8.8.8"
+                          onclick="pingOobIP(this)"
+                        >
+                          Ping (Should Work)
+                        </button>
+                        <span
+                          class="oob-ping-result ms-2"
+                          style="display: none"
+                        ></span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><strong>server-db-01</strong></td>
+                      <td>Chicago DC</td>
+                      <td>
+                        <span class="badge bg-warning">Database Server</span>
+                      </td>
+                      <td>192.168.3.10/24</td>
+                      <td>—</td>
+                      <td><em class="text-muted">No OOB IP configured</em></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row mt-4">
+        <div class="col-md-6">
+          <div class="card">
+            <div class="card-header bg-success text-white">
+              <h6 class="mb-0">🔧 Implementation Status</h6>
+            </div>
+            <div class="card-body">
+              <div class="mb-3">
+                <strong>✅ Backend (Django):</strong>
+                <ul class="list-unstyled ms-3">
+                  <li>✅ URL routing: <code>/dcim/ping-oob-ip/</code></li>
+                  <li>✅ View function: <code>ping_oob_ip()</code></li>
+                  <li>✅ CSRF protection enabled</li>
+                  <li>✅ JSON response handling</li>
+                  <li>✅ Subprocess ping execution</li>
+                </ul>
+              </div>
+              <div class="mb-3">
+                <strong>✅ Frontend (JavaScript):</strong>
+                <ul class="list-unstyled ms-3">
+                  <li>✅ AJAX request implementation</li>
+                  <li>✅ CSRF token detection (multiple methods)</li>
+                  <li>✅ Button state management</li>
+                  <li>✅ Error handling with user feedback</li>
+                  <li>✅ Auto-refresh functionality</li>
+                </ul>
+              </div>
+              <div>
+                <strong>✅ Table Integration:</strong>
+                <ul class="list-unstyled ms-3">
+                  <li>✅ Device table column definition</li>
+                  <li>✅ Render method for ping buttons</li>
+                  <li>✅ Bootstrap UI styling</li>
+                  <li>✅ Configurable column visibility</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="card">
+            <div class="card-header bg-info text-white">
+              <h6 class="mb-0">🐛 Debugging Information</h6>
+            </div>
+            <div class="card-body">
+              <p><strong>Check Browser Console for:</strong></p>
+              <ul>
+                <li>JavaScript loading confirmation</li>
+                <li>CSRF token detection status</li>
+                <li>AJAX request/response details</li>
+                <li>Error messages and stack traces</li>
+              </ul>
+
+              <p class="mt-3"><strong>Test Cases:</strong></p>
+              <ol>
+                <li>Click "Ping" on any button above</li>
+                <li>Observe button state changes (loading → result)</li>
+                <li>Check console for detailed logs</li>
+                <li>Verify auto-refresh after 5 seconds</li>
+              </ol>
+
+              <div class="alert alert-warning mt-3">
+                <small>
+                  <strong>Note:</strong> This is a test environment. In
+                  production NetBox: <br />• JavaScript should be included in
+                  device list templates <br />• CSRF tokens are provided by
+                  Django framework <br />• Real OOB IP addresses would be used
+                </small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row mt-4">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header bg-dark text-white">
+              <h6 class="mb-0">📋 Usage Instructions for NetBox</h6>
+            </div>
+            <div class="card-body">
+              <div class="row">
+                <div class="col-md-4">
+                  <h6>1. Enable Column</h6>
+                  <p>In NetBox device list:</p>
+                  <ol>
+                    <li>Go to <strong>Devices → Devices</strong></li>
+                    <li>Click <strong>"Configure Table"</strong></li>
+                    <li>Add <strong>"OOB IP Ping Status"</strong> column</li>
+                    <li>Save your table configuration</li>
+                  </ol>
+                </div>
+                <div class="col-md-4">
+                  <h6>2. Use Ping Feature</h6>
+                  <p>For devices with OOB IP:</p>
+                  <ol>
+                    <li>Locate device in the table</li>
+                    <li>Click <strong>"Ping"</strong> button</li>
+                    <li>Wait for result (Online/Offline)</li>
+                    <li>Button auto-refreshes after 5 seconds</li>
+                  </ol>
+                </div>
+                <div class="col-md-4">
+                  <h6>3. Troubleshooting</h6>
+                  <p>If issues occur:</p>
+                  <ol>
+                    <li>Check browser console for errors</li>
+                    <li>Verify OOB IP is configured</li>
+                    <li>Ensure network connectivity</li>
+                    <li>Check Django logs for backend errors</li>
+                  </ol>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Hidden CSRF token input (simulates Django form) -->
+    <input
+      type="hidden"
+      name="csrfmiddlewaretoken"
+      value="test-csrf-middleware-token-67890"
+    />
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="static/dcim/js/oob_ping.js"></script>
+
+    <script>
+      // Additional test script to verify functionality
+      document.addEventListener("DOMContentLoaded", function () {
+        console.log("🚀 OOB Ping Test Page Loaded");
+        console.log(
+          "✅ CSRF token (meta):",
+          document
+            .querySelector('meta[name="csrf-token"]')
+            ?.getAttribute("content") || "Not found",
+        );
+        console.log(
+          "✅ CSRF token (input):",
+          document.querySelector('input[name="csrfmiddlewaretoken"]')?.value ||
+            "Not found",
+        );
+
+        // Test button click handler
+        const buttons = document.querySelectorAll(".oob-ping-btn");
+        console.log(`✅ Found ${buttons.length} ping buttons on page`);
+      });
+    </script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "code",
+  "name": "dcim",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "code",
+      "name": "dcim",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {}

--- a/static/dcim/js/oob_ping.js
+++ b/static/dcim/js/oob_ping.js
@@ -67,13 +67,20 @@ function pingOobIP(button) {
 }
 
 function getCSRFToken() {
-  // Get CSRF token from meta tag or cookie
-  const token = document.querySelector('meta[name="csrf-token"]');
-  if (token) {
-    return token.getAttribute("content");
+  // Try multiple methods to get CSRF token
+  // Method 1: Django's standard csrf token input (most common in NetBox)
+  const csrfInput = document.querySelector('input[name="csrfmiddlewaretoken"]');
+  if (csrfInput) {
+    return csrfInput.value;
   }
 
-  // Fallback to cookie method
+  // Method 2: Meta tag
+  const metaToken = document.querySelector('meta[name="csrf-token"]');
+  if (metaToken) {
+    return metaToken.getAttribute("content");
+  }
+
+  // Method 3: Cookie method
   const cookies = document.cookie.split(";");
   for (let cookie of cookies) {
     const [name, value] = cookie.trim().split("=");
@@ -82,6 +89,13 @@ function getCSRFToken() {
     }
   }
 
+  // Method 4: Try to find any element with csrf data
+  const csrfElement = document.querySelector("[data-csrf-token]");
+  if (csrfElement) {
+    return csrfElement.getAttribute("data-csrf-token");
+  }
+
+  console.warn("CSRF token not found");
   return "";
 }
 

--- a/static/dcim/js/oob_ping.js
+++ b/static/dcim/js/oob_ping.js
@@ -18,11 +18,13 @@ function pingOobIP(button) {
   resultSpan.style.display = "none";
 
   // Make AJAX request to ping endpoint
+  const csrfToken = getCSRFToken();
+
   fetch("/dcim/ping-oob-ip/", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-CSRFToken": getCSRFToken(),
+      "X-CSRFToken": csrfToken,
     },
     body: JSON.stringify({ ip: ip }),
   })

--- a/static/dcim/js/oob_ping.js
+++ b/static/dcim/js/oob_ping.js
@@ -6,6 +6,8 @@ function pingOobIP(button) {
   const ip = button.getAttribute("data-ip");
   const resultSpan = button.nextElementSibling;
 
+  console.log("pingOobIP called with IP:", ip);
+
   if (!ip) {
     console.error("No IP address found");
     return;
@@ -19,6 +21,8 @@ function pingOobIP(button) {
 
   // Make AJAX request to ping endpoint
   const csrfToken = getCSRFToken();
+  console.log("Making ping request to:", "/dcim/ping-oob-ip/");
+  console.log("CSRF token:", csrfToken ? "found" : "not found");
 
   fetch("/dcim/ping-oob-ip/", {
     method: "POST",
@@ -28,7 +32,13 @@ function pingOobIP(button) {
     },
     body: JSON.stringify({ ip: ip }),
   })
-    .then((response) => response.json())
+    .then((response) => {
+      console.log("Response status:", response.status);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    })
     .then((data) => {
       // Hide button and show result
       button.style.display = "none";
@@ -52,19 +62,20 @@ function pingOobIP(button) {
     })
     .catch((error) => {
       console.error("Ping request failed:", error);
+      console.error("Error details:", error.message);
 
       // Reset button state
       button.disabled = false;
       button.innerHTML = "Ping";
 
-      // Show error result
+      // Show error result with more detail
       resultSpan.style.display = "inline";
-      resultSpan.innerHTML = '<span class="badge bg-danger">Error</span>';
+      resultSpan.innerHTML = `<span class="badge bg-danger" title="${error.message}">Error</span>`;
 
-      // Hide error after 3 seconds
+      // Hide error after 5 seconds
       setTimeout(() => {
         resultSpan.style.display = "none";
-      }, 3000);
+      }, 5000);
     });
 }
 

--- a/tables/devices.py
+++ b/tables/devices.py
@@ -267,17 +267,6 @@ class DeviceTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     inventory_item_count = tables.Column(
         verbose_name=_('Inventory items')
     )
-    ping_status = Column(empty_values=(), verbose_name='Ping Status')
-
-    def render_ping_status(self, record):
-        ip = record.primary_ip.address if record.primary_ip else None
-        if ip:
-            clean_ip = str(ip).split('/')[0]
-            return format_html(
-                '<span class="ping-status" data-ip="{}">Checking...</span>', clean_ip
-            )
-        return "—"
-
     def render_oob_ip_ping_status(self, record):
         ip = record.oob_ip.address if record.oob_ip else None
         if ip:

--- a/tables/devices.py
+++ b/tables/devices.py
@@ -2,6 +2,7 @@ import django_tables2 as tables
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django_tables2.utils import Accessor
+from django_tables2 import Column
 
 from dcim import models
 from netbox.tables import NetBoxTable, columns

--- a/views.py
+++ b/views.py
@@ -3787,7 +3787,6 @@ from django.views.decorators.csrf import csrf_exempt
 import subprocess
 import json
 
-@csrf_exempt
 @require_http_methods(["POST"])
 def ping_oob_ip(request):
     """


### PR DESCRIPTION
Add comprehensive test page for OOB IP ping functionality with improved CSRF token handling.

Changes made:
- Add new index.html test page demonstrating OOB IP ping feature
- Update package-lock.json to change project name from "code" to "dcim"
- Enhance oob_ping.js with better CSRF token detection and error handling
- Remove unused ping_status column from device table
- Remove @csrf_exempt decorator from ping_oob_ip view function

The test page includes sample device data, debugging information, and usage instructions for the NetBox OOB IP ping functionality.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ec325e99ca8349449950cc82b8f18a50/spark-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ec325e99ca8349449950cc82b8f18a50</projectId>-->
<!--<branchName>spark-oasis</branchName>-->